### PR TITLE
add support for replacing an entire row

### DIFF
--- a/lib/Tie/Array/CSV.pm
+++ b/lib/Tie/Array/CSV.pm
@@ -267,9 +267,13 @@ sub EXISTS {
 sub _update {
   my $self = shift;
 
-  $self->{csv}->combine(@{ $self->{fields} })
-    or croak "CSV combine error: " . $self->{csv}->error_diag();
-  $self->{file}[$self->{line_num}] = $self->{csv}->string;
+  if(@{ $self->{fields} }) {
+    $self->{csv}->combine(@{ $self->{fields} })
+      or croak "CSV combine error: " . $self->{csv}->error_diag();
+    $self->{file}[$self->{line_num}] = $self->{csv}->string;
+  } else {
+    $self->{file}[$self->{line_num}] = '';
+  }
 }
 
 __END__

--- a/t/80-set_row.t
+++ b/t/80-set_row.t
@@ -1,0 +1,40 @@
+
+use strict;
+use warnings;
+
+use Test::More;
+use File::Temp qw/tempfile/;
+
+use Text::CSV;
+
+use_ok( 'Tie::Array::CSV' );
+
+my $test_data = <<END_DATA;
+name,rank,serial number
+joel berger,plebe,1010101
+larry wall,general,1
+damian conway,colonel,1001
+END_DATA
+
+{
+  my ($fh, $file) = tempfile();
+  print $fh $test_data;
+
+  my @csv;
+  ok( tie(@csv, 'Tie::Array::CSV', $fh), "Tied CSV" );
+
+  @{ $csv[1] } = ('plicease', 'tinkerer', '47');
+  @{ $csv[2] } = ();
+
+  seek $fh, 0, 0;
+  my $parser = Text::CSV->new();
+
+  is_deeply( $parser->getline($fh), ["name", "rank", "serial number" ], "File was updated 1" );
+  is_deeply( $parser->getline($fh), ["plicease", "tinkerer", 47 ], "File was updated 1" );
+  is_deeply( $parser->getline($fh), [''], "File was updated 2" );
+  is_deeply( $parser->getline($fh), ["damian conway", "colonel", 1001 ], "File was updated 3" );
+  
+}
+
+done_testing();
+


### PR DESCRIPTION
if you try to set an entire row:

```perl
tie(@csv, 'Tie::Array::CSV', $fh), "Tied CSV";

@{ $csv[1] } = ('plicease', 'tinkerer', '47');
@{ $csv[2] } = ();
```

an exception (for either of the two above) is thrown: `CSV combine error:  at t/80-set_row.t line 26.`.  I think because first `CLEAR` is called, and then presumably a `PUSH` or maybe `SPLICE` (?), but `combine` doesn't like an empty list, which seems reasonable as I don't know that is encodable into CSV.

This patch special cases `CLEAR` to set the line to `''`, which allows both of the two assignments above to work, with the caveat that the second assignment to `()` doesn't round trip since it will come back as `('')`.  For my purposes I can live with that caveat, so if this isn't acceptable by DEFAULT, it would be nice for at least this to be optionally supported.

The included test illustrates the caveat.
